### PR TITLE
Support eu-south-2 (Spain) region

### DIFF
--- a/scripts/regions.js
+++ b/scripts/regions.js
@@ -18,6 +18,7 @@ const regions = [
     'ap-southeast-1',
     'ap-southeast-2',
     'eu-south-1',
+    'eu-south-2',
     'af-south-1',
     'me-south-1',
 ];


### PR DESCRIPTION
I encountered that eu-south-2 region was not available when using Bref CDK PhpFpmFunction construct.
The bref runtime version is available as shown in https://runtimes.bref.sh/?region=eu-south-2&version=2.4.10

```
const phpFpm = new PhpFpmFunction(this, 'api', {
    phpVersion: '8.3',
});
```

<img width="661" height="57" alt="Captura de pantalla 2025-08-20 a las 17 28 41" src="https://github.com/user-attachments/assets/184055b9-c124-4ea9-a990-611b3dd77f79" />
